### PR TITLE
Update menu and menubar selection background to improve contrast

### DIFF
--- a/themes/tokyo-night-light-color-theme.json
+++ b/themes/tokyo-night-light-color-theme.json
@@ -307,12 +307,12 @@
         "notificationsInfoIcon.foreground": "#637dbf",
 
         "menubar.selectionForeground":"#343b58",
-        "menubar.selectionBackground":"#2f3549",
+        "menubar.selectionBackground":"#7a85a8",
         "menubar.selectionBorder":"#c1c2c7",
         "menu.foreground":"#4c505e",
         "menu.background":"#cbccd1",
         "menu.selectionForeground":"#343b58",
-        "menu.selectionBackground":"#2f3549",
+        "menu.selectionBackground":"#7a85a8",
         "menu.separatorBackground":"#c1c2c7",
         "menu.border":"#c1c2c7"
     },


### PR DESCRIPTION
Hello @enkia! Thank you for the wonderful theme - I enjoy it :)

Have a suggestion regarding a color that makes menu items not visible in the "Tokyo Night Light" variation.

Here is what I have with the current implementation:
![image](https://user-images.githubusercontent.com/1942440/86398699-b24ddc80-bcae-11ea-8235-803a9e4ff956.png)

And another one

![image](https://user-images.githubusercontent.com/1942440/86398735-c1348f00-bcae-11ea-834b-51ed2065dfd8.png)

Here is the color I suggest (though any color of your choice with proper contrast will fit)

![image](https://user-images.githubusercontent.com/1942440/86398962-25575300-bcaf-11ea-98c6-3cd83a566c12.png)
