### PR TITLE
Fix illegible `terminal.selectionBackground` in light theme

### DIFF
--- a/themes/tokyo-night-light-color-theme.json
+++ b/themes/tokyo-night-light-color-theme.json
@@ -308,7 +308,7 @@
 
         "terminal.background": "#cbccd1",
         "terminal.foreground": "#4c505e",
-        "terminal.selectionBackground": "#d5d6db20",
+        "terminal.selectionBackground": "#d5d6db",
         "terminalCursor.foreground": "#828594",
 
         "terminal.ansiBlack": "#0f0f14",


### PR DESCRIPTION
The `20` opacity in light theme's `terminal.selectionBackground` makes the selection hardly illegible. Also it's not consistent with other selection background like `list.activeSelectionBackground`.