### PR TITLE
Add DevTools Port to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Install the [Tokyo Night Alfred Theme.](https://www.alfredapp.com/extras/theme/p
 **gtksourceview** (gnome text editor, gedit, builder, etc)      
 [tokyo-night-gtksourceview](https://github.com/kevin-nel/tokyo-night-gtksourceview) a theme for gtksourceview applications (by [kevin-nel](https://github.com/kevin-nel))
 
+**DevTools**   
+[Tokyo Night on DevTools](https://github.com/AdelFetner/devToolsExtension) a theme for most browsers' DevTools (by [AdelFetner](https://github.com/AdelFetner))
+
 <br><br>
 **Enjoy!**
 


### PR DESCRIPTION
This PR adds a port for most browsers' [DevTools](https://developer.chrome.com/docs/devtools)