### PR TITLE
feat: Add activityBarTop colors to theme

### DIFF
--- a/themes/tokyo-night-color-theme.json
+++ b/themes/tokyo-night-color-theme.json
@@ -90,6 +90,9 @@
         "activityBarBadge.background": "#3d59a1",
         "activityBarBadge.foreground": "#fff",
 
+        "activityBarTop.foreground": "#787c99",
+        "activityBarTop.inactiveForeground": "#3b3e52",
+
         "tree.indentGuidesStroke": "#2b2b3b",
         "sideBar.foreground": "#787c99",
         "sideBar.background": "#16161e",

--- a/themes/tokyo-night-light-color-theme.json
+++ b/themes/tokyo-night-light-color-theme.json
@@ -89,6 +89,9 @@
         "activityBarBadge.background": "#34548a",
         "activityBarBadge.foreground": "#fff",
 
+        "activityBarTop.foreground": "#4c505e",
+        "activityBarTop.inactiveForeground": "#828594",
+
         "tree.indentGuidesStroke": "#c1c2c7",
         "sideBar.foreground": "#4c505e",
         "sideBar.background": "#cbccd1",

--- a/themes/tokyo-night-storm-color-theme.json
+++ b/themes/tokyo-night-storm-color-theme.json
@@ -90,6 +90,9 @@
         "activityBarBadge.background": "#3d59a1",
         "activityBarBadge.foreground": "#fff",
 
+        "activityBarTop.foreground": "#7982a9",
+        "activityBarTop.inactiveForeground": "#41496b",
+
         "tree.indentGuidesStroke": "#2e344f",
         "sideBar.foreground": "#7982a9",
         "sideBar.background": "#1f2335",


### PR DESCRIPTION
tokyo-night-storm

Before:
![image](https://github.com/enkia/tokyo-night-vscode-theme/assets/47070852/df7dd951-f0d9-4423-9d00-a50236ecb4ea)

After:
![image](https://github.com/enkia/tokyo-night-vscode-theme/assets/47070852/5508a88c-8ce5-4178-bb37-3185c8ca0c0e)
