### PR TITLE
feat: add gitk and git-gui to the "Other Ports" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Install the [Tokyo Night Alfred Theme.](https://www.alfredapp.com/extras/theme/p
 **gitk**
 [gitk-tokyonight](https://github.com/domwalters/gitk-tokyonight) a theme for [gitk](https://git-scm.com/docs/gitk) (by [Dominic Walters](https://github.com/domWalters))
 
+**git-gui**
+[git-gui-tokyonight](https://github.com/domwalters/git-gui-tokyonight) a theme for [git-gui](https://git-scm.com/docs/git-gui/) (by [Dominic Walters](https://github.com/domWalters))
+
 <br><br>
 **Enjoy!**
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Install the [Tokyo Night Alfred Theme.](https://www.alfredapp.com/extras/theme/p
 **gtksourceview** (gnome text editor, gedit, builder, etc)      
 [tokyo-night-gtksourceview](https://github.com/kevin-nel/tokyo-night-gtksourceview) a theme for gtksourceview applications (by [kevin-nel](https://github.com/kevin-nel))
 
+**gitk**
+[gitk-tokyonight](https://github.com/domwalters/gitk-tokyonight) a theme for [gitk](https://git-scm.com/docs/gitk) (by [Dominic Walters](https://github.com/domWalters))
+
 <br><br>
 **Enjoy!**
 


### PR DESCRIPTION
I recently published configs for `gitk` and `git-gui` in the tokyonight colours.

It'd be great if they could be mentioned on here!