### PR TITLE
themes: Add stronger distinction between selected and unselected tabs

### DIFF
--- a/themes/tokyo-night-color-theme.json
+++ b/themes/tokyo-night-color-theme.json
@@ -283,6 +283,7 @@
         "tab.inactiveModifiedBorder": "#1f202e",
         "tab.unfocusedActiveBorder": "#1f202e",
         "tab.lastPinnedBorder": "#222333",
+        "tab.selectedBackground": "#1a1b26",
 
         "panel.background": "#16161e",
         "panel.border": "#101014",

--- a/themes/tokyo-night-light-color-theme.json
+++ b/themes/tokyo-night-light-color-theme.json
@@ -278,7 +278,7 @@
         "tab.hoverBackground": "#dadce3",
         "tab.activeBorder": "#2959aa",
         // "tab.selectedBorderTop": "#e6e7ed",
-        "tab.selectedBackground": "#d6d8df",
+        "tab.selectedBackground": "#e6e7ed",
         "tab.inactiveForeground": "#363c4d",
         "tab.border": "#c1c2c7",
         "tab.unfocusedActiveForeground": "#363c4d",

--- a/themes/tokyo-night-storm-color-theme.json
+++ b/themes/tokyo-night-storm-color-theme.json
@@ -284,6 +284,7 @@
         "tab.inactiveModifiedBorder": "#282d42",
         "tab.unfocusedActiveBorder": "#3b4261",
         "tab.lastPinnedBorder": "#2c3147",
+        "tab.selectedBackground": "#24283b",
 
         "panel.background": "#1f2335",
         "panel.border": "#1b1e2e",


### PR DESCRIPTION
This PR adds some stronger distinction between selected and unselected tabs by using the editor background color as background color for selected tabs. Happy to change if some other color should be used instead.

Closes: https://github.com/tokyo-night/tokyo-night-vscode-theme/issues/100