### PR TITLE
Fix: Extending italic disabling to multi-line comments and python docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tokyo Night Light
 Font used in the screenshots is [JetBrains Mono.](https://www.jetbrains.com/lp/mono/)
 
 ## Disabling Italics
-Paste this into your [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations) to disable italics.
+Paste this into your [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations) to disable italics for comments, storage, keyword Flow, vue attributes, and decorators.
 
 ```javascript
 "editor.tokenColorCustomizations": {
@@ -33,7 +33,11 @@ Paste this into your [settings.json](https://code.visualstudio.com/docs/getstart
                 "meta.directive.vue entity.other.attribute-name.html",
                 "tag.decorator.js entity.name.tag.js",
                 "tag.decorator.js punctuation.definition.tag.js",
-                "storage.modifier"
+                "storage.modifier",
+                "string.quoted.docstring.multi",
+                "string.quoted.docstring.multi.python punctuation.definition.string.begin",
+                "string.quoted.docstring.multi.python punctuation.definition.string.end",
+                "string.quoted.docstring.multi.python constant.character.escape"
             ],
             "settings": {
                 "fontStyle": ""


### PR DESCRIPTION
### Description
This PR fixes the inconsistent italic styling between single-line and multi-line comments in the tokenColorCustomizations settings within the README file where it talks about disabling italics. When I tried that, it only disabled the italics for the single-line comments, and not the multi-line comments (both double-quoted and single-quoted). PS. I was working in python3.12 when I noticed this.

### Context
I'm new to open source contributions and would appreciate any feedback on:
- Whether this is the right approach to fix this issue
- If the documentation changes are clear and helpful
- Any other improvements I could make

### Changes
- Added string.quoted.docstring.multi pattern
- Added Python-specific docstring patterns
- Added support for both single and double quoted multi-line comments

Thank you for taking the time to review my contribution!